### PR TITLE
add python-tk, backend for plot with matplotlib in python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:rolling
-MAINTAINER adin 
+MAINTAINER adin
 
 ENV PYTHON_VERSION 3.6
 ENV OPENCV_VERSION 3.2.0
@@ -27,7 +27,7 @@ RUN apt-get -y update -qq && \
                        libavcodec-dev \
                        libavformat-dev \
                        libswscale-dev \
-                        
+
                        # Optional
                        libtbb2 libtbb-dev \
                        libjpeg-dev \
@@ -41,6 +41,9 @@ RUN apt-get -y update -qq && \
                        # Missing libraries for GTK
                        libatk-adaptor \
                        libcanberra-gtk-module \
+
+                       # For use matplotlib.pyplot in python
+                       python$PYTHON_VERSION-tk \
 
                        # Tools
                        imagemagick \
@@ -66,7 +69,7 @@ RUN apt-get -y update -qq && \
 RUN pip${PYTHON_VERSION%%.*} install --no-cache-dir --upgrade pip &&\
     pip${PYTHON_VERSION%%.*} install --no-cache-dir numpy matplotlib
 
-    # Get OpenCV 
+    # Get OpenCV
 RUN git clone https://github.com/opencv/opencv.git &&\
     cd opencv &&\
     git checkout $OPENCV_VERSION &&\
@@ -108,7 +111,7 @@ RUN git clone https://github.com/opencv/opencv.git &&\
     # Clean the install from sources
     cd / &&\
     rm -r /opencv &&\
-    rm -r /opencv_contrib 
+    rm -r /opencv_contrib
 
 # Change working dirs
 WORKDIR /builds


### PR DESCRIPTION
When you use plot from matplotlib in this docker image get this error:

<img width="755" alt="screen shot 2017-08-14 at 20 57 09" src="https://user-images.githubusercontent.com/4089219/29301010-9e5a66aa-814f-11e7-8686-96cb82cb744f.png">

This error is solved installing `python-tk`. For this specific implementation, the error was solved adding `python$PYTHON_VERSION-tk \` in `apt-get` packages installations.