### PR TITLE
add scipy to pip installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,9 @@ RUN apt-get -y update -qq && \
 # Note that ${PYTHON_VERSION%%.*} extracts the major version
 # Details: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#Shell-Parameter-Expansion
 RUN pip${PYTHON_VERSION%%.*} install --no-cache-dir --upgrade pip &&\
-    pip${PYTHON_VERSION%%.*} install --no-cache-dir numpy matplotlib
+    pip${PYTHON_VERSION%%.*} install --no-cache-dir numpy matplotlib scipy
 
-    # Get OpenCV 
+    # Get OpenCV
 RUN git clone https://github.com/opencv/opencv.git &&\
     cd opencv &&\
     git checkout $OPENCV_VERSION &&\


### PR DESCRIPTION
When you `scipy` in this docker image get this error:

<img width="526" alt="screen shot 2017-08-15 at 00 33 04" src="https://user-images.githubusercontent.com/4089219/29301262-5b62dd3a-8151-11e7-8774-af9a4d280e2a.png">


This error was solved adding `scipy` in `pip` installation